### PR TITLE
Improve styles

### DIFF
--- a/styling.css
+++ b/styling.css
@@ -17,6 +17,10 @@ body {
   color: white;
   font-family: "Poppins", sans-serif;
 
+  /* Readable line length */
+  max-width: 1060px;
+  margin-inline: auto;
+
   /* Fix height */
   padding-block: 1px;
   margin-block: 0;

--- a/styling.css
+++ b/styling.css
@@ -5,25 +5,21 @@
   box-sizing: border-box;
 }
 
+body,
+html {
+  height: 100%;
+}
+
 body {
   background-color: rgb(24, 26, 27);
+  color: white;
+  font-family: "Poppins", sans-serif;
   padding-block: 1px;
   margin-block: 0;
 }
-.stuff {
-  text-align: center;
-  padding-left: 60px;
-  padding-right: 60px;
-}
-p {
-  color: white;
-  font-family: "Poppins", sans-serif;
-}
 
 h1 {
-  color: white;
   text-align: center;
-  font-family: "Poppins", sans-serif;
 }
 
 :where(a) {
@@ -34,9 +30,10 @@ h1 {
   color: #d59;
 }
 
-body,
-html {
-  height: 100%;
+.stuff {
+  text-align: center;
+  padding-left: 60px;
+  padding-right: 60px;
 }
 
 #particles-js canvas {

--- a/styling.css
+++ b/styling.css
@@ -26,6 +26,14 @@ h1 {
   font-family: "Poppins", sans-serif;
 }
 
+:where(a) {
+  color: #66f;
+  text-underline-offset: 0.2em;
+}
+:where(a):visited {
+  color: #d59;
+}
+
 body,
 html {
   height: 100%;

--- a/styling.css
+++ b/styling.css
@@ -1,50 +1,53 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inconsolata&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Poppins&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inconsolata&display=swap");
+
 body {
-    background-color: rgb(24,26,27);
+  background-color: rgb(24, 26, 27);
 }
 .stuff {
-    text-align: center;
-    padding-left: 60px;
-    padding-right: 60px;
+  text-align: center;
+  padding-left: 60px;
+  padding-right: 60px;
 }
- p {
-    color: white;
-    font-family: 'Poppins', sans-serif;
+p {
+  color: white;
+  font-family: "Poppins", sans-serif;
 }
 
 h1 {
-    color: white;
-    text-align: center;
-    font-family: 'Poppins', sans-serif;
+  color: white;
+  text-align: center;
+  font-family: "Poppins", sans-serif;
 }
 
-body,html 
-{
-    height: 100%
+body,
+html {
+  height: 100%;
 }
-#particles-js canvas
-{
-    display: block;
-    -webkit-transform: scale(1);
-    -ms-transform: scale(1);
-    transform: scale(1);
-    opacity: 1;
-    -webkit-transition: opacity .8s ease, -webkit-transform 1.4s ease;
-    transition: opacity .8s ease, transform 1.4s ease
+
+#particles-js canvas {
+  display: block;
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  opacity: 1;
+  -webkit-transition:
+    opacity 0.8s ease,
+    -webkit-transform 1.4s ease;
+  transition:
+    opacity 0.8s ease,
+    transform 1.4s ease;
 }
-#particles-js 
-{
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    z-index: -10;
-    top: 0;
-    left: 0
+#particles-js {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  z-index: -10;
+  top: 0;
+  left: 0;
 }
-canvas
-{
-    display:block;
-    position: fixed;
-    z-index: -1;
+canvas {
+  display: block;
+  position: fixed;
+  z-index: -1;
 }

--- a/styling.css
+++ b/styling.css
@@ -1,6 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Inconsolata&display=swap");
 
+/* Global styles */
 * {
   box-sizing: border-box;
 }
@@ -10,18 +11,23 @@ html {
   height: 100%;
 }
 
+/* Body styles */
 body {
   background-color: rgb(24, 26, 27);
   color: white;
   font-family: "Poppins", sans-serif;
+
+  /* Fix height */
   padding-block: 1px;
   margin-block: 0;
 }
 
+/* General styles */
 h1 {
   text-align: center;
 }
 
+/* Cleaner links */
 :where(a) {
   color: #66f;
   text-underline-offset: 0.2em;
@@ -30,6 +36,7 @@ h1 {
   color: #d59;
 }
 
+/* Class styles */
 .stuff {
   text-align: center;
   padding-left: 60px;

--- a/styling.css
+++ b/styling.css
@@ -1,8 +1,14 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Inconsolata&display=swap");
 
+* {
+  box-sizing: border-box;
+}
+
 body {
   background-color: rgb(24, 26, 27);
+  padding-block: 1px;
+  margin-block: 0;
 }
 .stuff {
   text-align: center;


### PR DESCRIPTION
Fixes a few issues with the styles:

- Body margin causing the screen to scroll
- Elements overflowing the body (you may want to instead consider a classic marign reset and `* + *` style instead of the provided padding fix)
- No comments

Also adds some nice things:

- Better contrast for link colors
- Readable line length

All of these fixes are atomic, so you can remove commits to only have specific changes at your leisure.

Current:

![image](https://github.com/zoey-on-github/zoey-on-github.github.io/assets/109556932/c062aa7a-5c85-47b6-bb91-c76d14495490)

Proposed:

![image](https://github.com/zoey-on-github/zoey-on-github.github.io/assets/109556932/cf4b358b-36ed-4458-b8da-81a6b9e02f8f)
